### PR TITLE
cronie: version bump to 1.5.7

### DIFF
--- a/utils/cronie/DETAILS
+++ b/utils/cronie/DETAILS
@@ -1,9 +1,9 @@
            SPELL=cronie
-         VERSION=1.4.12
+         VERSION=1.5.7
           SOURCE=$SPELL-$VERSION.tar.gz
-   SOURCE_URL[0]=https://fedorahosted.org/releases/c/r/$SPELL/$SOURCE
+   SOURCE_URL[0]=http://github.com/cronie-crond/cronie/releases/download/$SPELL-$VERSION/$SOURCE
     SOURCE_HINTS="no-check-certificate"
-     SOURCE_HASH=sha512:ff17c9a1ba39957727db390d28d21248f05414f55119094d99a646695698e1b148b920f3fc91e9733b862bc8ce226824d290fff51abe17410a0e63ab3b424865
+     SOURCE_HASH=sha512:c306468d2e8d618a168e55204796f15d845520130d9601395e6413c55a71e94b4264a73e2e3f5d7011b3e53af9dad812f56662de3a7c9e50977d57b2a49a6893
 SOURCE_DIRECTORY="$BUILD_DIRECTORY/$SPELL-$VERSION"
         WEB_SITE=https://fedorahosted.org/cronie/
       LICENSE[0]=ISC

--- a/utils/cronie/DETAILS
+++ b/utils/cronie/DETAILS
@@ -1,7 +1,7 @@
            SPELL=cronie
          VERSION=1.5.7
           SOURCE=$SPELL-$VERSION.tar.gz
-   SOURCE_URL[0]=http://github.com/cronie-crond/cronie/releases/download/$SPELL-$VERSION/$SOURCE
+   SOURCE_URL[0]=https://github.com/cronie-crond/cronie/releases/download/$SPELL-$VERSION/$SOURCE
     SOURCE_HINTS="no-check-certificate"
      SOURCE_HASH=sha512:c306468d2e8d618a168e55204796f15d845520130d9601395e6413c55a71e94b4264a73e2e3f5d7011b3e53af9dad812f56662de3a7c9e50977d57b2a49a6893
 SOURCE_DIRECTORY="$BUILD_DIRECTORY/$SPELL-$VERSION"

--- a/utils/cronie/HISTORY
+++ b/utils/cronie/HISTORY
@@ -1,3 +1,7 @@
+2021-12-23 Stephane Fontaine <esselfe16@gmail.com>
+	* DETAILS: updated spell to 1.5.7
+	* DETAILS: updated source URL
+
 2014-11-26 Vlad Glagolev <stealth@sourcemage.org>
 	* DETAILS: updated spell to 1.4.12
 


### PR DESCRIPTION
The source URL has changed since fedorahosted.org has shutdown.