### PR TITLE
python-sphinx: => 5.1.1

### DIFF
--- a/python-pypi/python-sphinx/DETAILS
+++ b/python-pypi/python-sphinx/DETAILS
@@ -1,8 +1,8 @@
            SPELL=python-sphinx
-         VERSION=4.4.0
+         VERSION=5.1.1
           SOURCE="Sphinx-${VERSION}.tar.gz"
    SOURCE_URL[0]=https://pypi.python.org/packages/source/S/Sphinx/${SOURCE}
-     SOURCE_HASH=sha512:f5780a7da7a5d758b0e145ab9a7f191a9c65fd3ca4624ca3a04f0d161e3cd6c7133df53ff56e42f012687cbce0460178c2e7957974b5b929b341c98db996c640
+     SOURCE_HASH=sha512:82cb4c435b0f6cee6bf80b81028f06e425e3d6fb5614e64b1f5a8c715ece80b697b5b55e04f3afe26236bb4590de9cd41008d6480c4b3d895803d83e914afff3
 SOURCE_DIRECTORY="${BUILD_DIRECTORY}/Sphinx-${VERSION}"
 	WEB_SITE="https://www.sphinx-doc.org"
       LICENSE[0]=PYTHON

--- a/python-pypi/python-sphinx/HISTORY
+++ b/python-pypi/python-sphinx/HISTORY
@@ -1,3 +1,6 @@
+2022-08-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 5.1.1
+
 2022-01-29  Florian Franzmann  <bwlf@bandrate.org>
 	* DETAILS: version 4.4.0
 


### PR DESCRIPTION
Fixes newer packages (extra-cmake-modules and polybar, for example) not compiling when enabling an optional dependency on python-sphinx for documentation building