### PR TITLE
kwin: <= 5.26.1

### DIFF
--- a/plasma/kwin/DETAILS
+++ b/plasma/kwin/DETAILS
@@ -1,5 +1,5 @@
            SPELL=kwin
-         VERSION=5.26.2
+         VERSION=5.26.1
           SOURCE=$SPELL-$VERSION.tar.xz
       SOURCE_URL=https://download.kde.org/stable/plasma/${VERSION}/$SOURCE
          SOURCE2=$SOURCE.sig

--- a/plasma/kwin/HISTORY
+++ b/plasma/kwin/HISTORY
@@ -1,3 +1,5 @@
+2022-11-03 Brian Madonna  <bmadonnaster@gmail.com>
+        * DETAILS: version 5.26.1 5.26.2 source file don't exist on project site.
 2022-10-26 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 5.26.2
 


### PR DESCRIPTION
5.26.2 uses the file from 5.26.1 it was never updated to 5.26.2 by the plasma project. 