### PR TITLE
sddm: add scm branch to fix qt5 version mismatch

### DIFF
--- a/qt5-cmake/sddm/DETAILS
+++ b/qt5-cmake/sddm/DETAILS
@@ -1,12 +1,22 @@
+. $"GRIMOIRE/FUNCTIONS"
            SPELL=sddm
-         VERSION=0.19.0
+if [[ "${SDDM_BRANCH}" == "scm" ]]; then
+	VERSION=$(get_scm_version)
+	SOURCE=$SPELL-develop.zip
+	SOURCE_DIRECTORY=$BUILD_DIRECTORY/$SPELL-develop
+	FORCE_DOWNLOAD="on"
+	SOURCE_URL[0]=https://github.com/sddm/sddm/archive/refs/heads/develop.zip
+        SOURCE_IGNORE=volatile 
+else
+	VERSION=0.19.0
      SOURCE_HASH=sha512:0a40816bc105a1e930fec2d65fabff0ae7e27c641235d90e41f6fbaa86af4bb774a9e30f7548ce2c6c791e6d4f8195b02afddedca60a9e7c77447702e728edc3
   SECURITY_PATCH=1
           SOURCE=sddm-$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$SPELL-$VERSION
         WEB_SITE=https://github.com/sddm/sddm
       SOURCE_URL=$WEB_SITE/releases/download/v$VERSION/$SOURCE
-         ENTERED=20140505
+fi         
+      ENTERED=20140505
       LICENSE[0]=GPL
         KEYWORDS="qt5"
            SHORT="QML based X11 display manager"

--- a/qt5-cmake/sddm/HISTORY
+++ b/qt5-cmake/sddm/HISTORY
@@ -1,3 +1,7 @@
+2022-11-07 Conner Clere <connerclere@gmail.com>
+	* DETAILS: Add scm branch
+	* PREPARE: new file, add scm branch
+
 2020-11-04 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 0.19.0
 

--- a/qt5-cmake/sddm/PREPARE
+++ b/qt5-cmake/sddm/PREPARE
@@ -1,0 +1,2 @@
+. "$GRIMOIRE/FUNCTIONS" &&
+prepare_select_branch stable scm


### PR DESCRIPTION
qt5 has changed enough that sddm 0.19.0 no longer compiles with the newest version of it - this grabs the latest snapshot of sddm which has commits that fix the issue (among other fixes i'm sure)