### PR TITLE
Lxqt spellset update (lxqt-session broken with procps-ng v4.1, downgrade to v4 is needed for compilation)

### DIFF
--- a/lxqt/libfm-qt/DETAILS
+++ b/lxqt/libfm-qt/DETAILS
@@ -1,5 +1,5 @@
            SPELL=libfm-qt
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/libfm-qt/releases/download/$VERSION/$SOURCE

--- a/lxqt/libfm-qt/HISTORY
+++ b/lxqt/libfm-qt/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: VERSION 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/liblxqt/DEPENDS
+++ b/lxqt/liblxqt/DEPENDS
@@ -1,6 +1,9 @@
 source $GRIMOIRE/QT5_DEPENDS &&
-depends lxqt-build-tools &&
-depends libqtxdg &&
-depends qttools  &&
-depends kwindowsystem &&
+depends lxqt-build-tools     &&
+depends libqtxdg             &&
+depends qttools              &&
+depends kwindowsystem        &&
+depends libxscrnsaver        &&
+depends qtx11extras          &&
+
 optional_depends polkit-qt5 '' '-DBUILD_BACKLIGHT_LINUX_BACKEND=0' 'build backlight backend'

--- a/lxqt/liblxqt/DETAILS
+++ b/lxqt/liblxqt/DETAILS
@@ -1,5 +1,5 @@
            SPELL=liblxqt
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/liblxqt/releases/download/$VERSION/$SOURCE

--- a/lxqt/liblxqt/HISTORY
+++ b/lxqt/liblxqt/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DEPENDS: add libxscrnsaver and qtx11extras deps
+
 2022-11-23 Conner Clere <connerclere@gmail.com>
 	* DETAILS: version 1.2.0
 

--- a/lxqt/liblxqt/HISTORY
+++ b/lxqt/liblxqt/HISTORY
@@ -1,3 +1,6 @@
+2022-11-23 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/libqtxdg/DETAILS
+++ b/lxqt/libqtxdg/DETAILS
@@ -1,5 +1,5 @@
            SPELL=libqtxdg
-         VERSION=3.9.1
+         VERSION=3.10.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/libqtxdg/releases/download/$VERSION/$SOURCE

--- a/lxqt/libqtxdg/HISTORY
+++ b/lxqt/libqtxdg/HISTORY
@@ -1,3 +1,6 @@
+2022-11-23 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 3.10.0
+
 2022-07-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 3.9.1
 

--- a/lxqt/lximage-qt/DETAILS
+++ b/lxqt/lximage-qt/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lximage-qt
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lximage-qt/releases/download/$VERSION/$SOURCE

--- a/lxqt/lximage-qt/HISTORY
+++ b/lxqt/lximage-qt/HISTORY
@@ -1,3 +1,6 @@
+2022-11-23 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-about/DETAILS
+++ b/lxqt/lxqt-about/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-about
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-about/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-about/HISTORY
+++ b/lxqt/lxqt-about/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-build-tools/DETAILS
+++ b/lxqt/lxqt-build-tools/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-build-tools
-         VERSION=0.11.0
+         VERSION=0.12.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-build-tools/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-build-tools/HISTORY
+++ b/lxqt/lxqt-build-tools/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.12.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 0.11.0
 	* BUILD: add forgotten file

--- a/lxqt/lxqt-config/DEPENDS
+++ b/lxqt/lxqt-config/DEPENDS
@@ -1,11 +1,12 @@
 source $GRIMOIRE/QT5_DEPENDS &&
-depends lxqt-build-tools &&
-depends qttools &&
-depends qtsvg   &&
-depends libkscreen2 &&
-depends liblxqt &&
-depends libinput &&
-depends libxcb  &&
-depends libx11  &&
-depends libxi   &&
-depends zlib
+depends lxqt-build-tools     &&
+depends qttools              &&
+depends qtsvg                &&
+depends libkscreen2          &&
+depends liblxqt              &&
+depends libinput             &&
+depends libxcb               &&
+depends libx11               &&
+depends libxi                &&
+depends zlib                 &&
+depends xf86-input-libinput

--- a/lxqt/lxqt-config/DETAILS
+++ b/lxqt/lxqt-config/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-config
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-config/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-config/HISTORY
+++ b/lxqt/lxqt-config/HISTORY
@@ -1,4 +1,7 @@
 2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DEPENDS: add xf86-input-libinput to deps
+
+2022-11-24 Conner Clere <connerclere@gmail.com>
 	* DETAILS: version 1.2.0
 
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>

--- a/lxqt/lxqt-config/HISTORY
+++ b/lxqt/lxqt-config/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-globalkeys/DETAILS
+++ b/lxqt/lxqt-globalkeys/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-globalkeys
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-globalkeys/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-globalkeys/HISTORY
+++ b/lxqt/lxqt-globalkeys/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-notificationd/DETAILS
+++ b/lxqt/lxqt-notificationd/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-notificationd
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-notificationd/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-notificationd/HISTORY
+++ b/lxqt/lxqt-notificationd/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-panel/DEPENDS
+++ b/lxqt/lxqt-panel/DEPENDS
@@ -1,13 +1,15 @@
 source $GRIMOIRE/QT5_DEPENDS &&
-depends lxqt-build-tools &&
-depends lxqt-globalkeys  &&
-depends libsysstat &&
-depends liblxqt  &&
-depends qttools  &&
-depends kwindowsystem &&
-depends libdbusmenu-qt5 &&
-depends libxkbcommon  &&
-depends libxcb        &&
-depends libstatgrab   &&
+depends lxqt-build-tools     &&
+depends lxqt-globalkeys      &&
+depends libsysstat           &&
+depends liblxqt              &&
+depends qttools              &&
+depends kwindowsystem        &&
+depends libdbusmenu-qt5      &&
+depends libxkbcommon         &&
+depends libxcb               &&
+depends libstatgrab          &&
+
 optional_depends pulseaudio -DVOLUME_USE_PULSEAUDIO={yes,no} 'use pulse-audio' &&
-optional_depends alsa-lib -DVOLUME_USE_ALSA={yes,no} 'use alsa'
+optional_depends alsa-lib -DVOLUME_USE_ALSA={yes,no} 'use alsa'                &&
+optional_depends lm_sensors -DSENSORS_PLUGIN={yes,no} 'build sensors plugin'

--- a/lxqt/lxqt-panel/DETAILS
+++ b/lxqt/lxqt-panel/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-panel
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-panel/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-panel/HISTORY
+++ b/lxqt/lxqt-panel/HISTORY
@@ -1,4 +1,7 @@
 2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DEPENDS: add lm_sensors optional dependency
+
+2022-11-24 Conner Clere <connerclere@gmail.com>
 	* DETAILS: version 1.2.0
 
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>

--- a/lxqt/lxqt-panel/HISTORY
+++ b/lxqt/lxqt-panel/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 	* DEPENDS: add libdbusmenu-qt5

--- a/lxqt/lxqt-powermanagement/DETAILS
+++ b/lxqt/lxqt-powermanagement/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-powermanagement
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-powermanagement/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-powermanagement/HISTORY
+++ b/lxqt/lxqt-powermanagement/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-runner/DETAILS
+++ b/lxqt/lxqt-runner/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-runner
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-runner/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-runner/HISTORY
+++ b/lxqt/lxqt-runner/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/lxqt-session/DETAILS
+++ b/lxqt/lxqt-session/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-session
-         VERSION=1.1.1
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-session/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-session/HISTORY
+++ b/lxqt/lxqt-session/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-07-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.1
 	* DEPENDS: add qtxdg-tools

--- a/lxqt/lxqt-session/PRE_BUILD
+++ b/lxqt/lxqt-session/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build       &&
+cd $SOURCE_DIRECTORY    &&
+apply_patch_dir patches

--- a/lxqt/lxqt-session/patches/lxqt-session-1.2.0-procps-ng-4.0.patch
+++ b/lxqt/lxqt-session/patches/lxqt-session-1.2.0-procps-ng-4.0.patch
@@ -1,0 +1,52 @@
+diff -up lxqt-session-1.2.0/lxqt-session/src/procreaper.cpp.omv~ lxqt-session-1.2.0/lxqt-session/src/procreaper.cpp
+--- lxqt-session-1.2.0/lxqt-session/src/procreaper.cpp.omv~	2022-06-19 02:12:01.835293407 +0200
++++ lxqt-session-1.2.0/lxqt-session/src/procreaper.cpp	2022-06-19 02:29:22.297426001 +0200
+@@ -29,7 +29,7 @@
+ #include "log.h"
+ #if defined(Q_OS_LINUX)
+ #include <sys/prctl.h>
+-#include <proc/readproc.h>
++#include <procps/pids.h>
+ #elif defined(Q_OS_FREEBSD)
+ #include <sys/procctl.h>
+ #include <libutil.h>
+@@ -109,16 +109,21 @@ void ProcReaper::stop(const std::set<int
+     const pid_t my_pid = ::getpid();
+     std::vector<pid_t> children;
+ #if defined(Q_OS_LINUX)
+-    PROCTAB * proc_dir = ::openproc(PROC_FILLSTAT);
+-    while (proc_t * proc = ::readproc(proc_dir, nullptr))
++    struct pids_info *info = NULL;
++    enum pids_item items[] = { PIDS_ID_PPID, PIDS_ID_TGID };
++    enum rel_items { rel_ppid, rel_tgid };
++    struct pids_stack *stack;
++    procps_pids_new(&info, items, 2);
++    while ((stack = procps_pids_get(info, PIDS_FETCH_TASKS_ONLY)))
+     {
+-        if (proc->ppid == my_pid)
++        const int ppid = PIDS_VAL(rel_ppid, s_int, stack, info);
++        if (ppid == my_pid)
+         {
+-            children.push_back(proc->tgid);
++	    const int tgid = PIDS_VAL(rel_tgid, s_int, stack, info);
++            children.push_back(tgid);
+         }
+-        ::freeproc(proc);
+     }
+-    ::closeproc(proc_dir);
++    procps_pids_unref(&info);
+ #elif defined(Q_OS_FREEBSD)
+     int cnt = 0;
+     if (kinfo_proc *proc_info = kinfo_getallproc(&cnt))
+diff -up lxqt-session-1.2.0/CMakeLists.txt.omv~ lxqt-session-1.2.0/CMakeLists.txt
+--- lxqt-session-1.2.0/CMakeLists.txt.omv~	2022-06-19 02:30:44.594909306 +0200
++++ lxqt-session-1.2.0/CMakeLists.txt	2022-06-19 02:30:49.965940879 +0200
+@@ -35,7 +35,7 @@ find_package(X11 REQUIRED)
+ message(STATUS "Building with Qt${Qt5Core_VERSION}")
+ find_package(PkgConfig REQUIRED)
+ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    pkg_search_module(PROCPS REQUIRED libprocps)
++    pkg_search_module(PROCPS REQUIRED libproc-2)
+ endif()
+ 
+ # Please don't move, must be after lxqt

--- a/lxqt/lxqt-themes/DETAILS
+++ b/lxqt/lxqt-themes/DETAILS
@@ -1,5 +1,5 @@
            SPELL=lxqt-themes
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/lxqt-themes/releases/download/$VERSION/$SOURCE

--- a/lxqt/lxqt-themes/HISTORY
+++ b/lxqt/lxqt-themes/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/pcmanfm-qt/DETAILS
+++ b/lxqt/pcmanfm-qt/DETAILS
@@ -1,5 +1,5 @@
            SPELL=pcmanfm-qt
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/pcmanfm-qt/releases/download/$VERSION/$SOURCE

--- a/lxqt/pcmanfm-qt/HISTORY
+++ b/lxqt/pcmanfm-qt/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/qterminal/DETAILS
+++ b/lxqt/qterminal/DETAILS
@@ -1,5 +1,5 @@
            SPELL=qterminal
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/qterminal/releases/download/$VERSION/$SOURCE

--- a/lxqt/qterminal/HISTORY
+++ b/lxqt/qterminal/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/qtermwidget/DETAILS
+++ b/lxqt/qtermwidget/DETAILS
@@ -1,5 +1,5 @@
            SPELL=qtermwidget
-         VERSION=1.1.0
+         VERSION=1.2.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/qtermwidget/releases/download/$VERSION/$SOURCE

--- a/lxqt/qtermwidget/HISTORY
+++ b/lxqt/qtermwidget/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 1.2.0
+
 2022-04-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 1.1.0
 

--- a/lxqt/qtxdg-tools/DETAILS
+++ b/lxqt/qtxdg-tools/DETAILS
@@ -1,5 +1,5 @@
            SPELL=qtxdg-tools
-         VERSION=3.9.1
+         VERSION=3.10.0
           SOURCE=$SPELL-$VERSION.tar.xz
          SOURCE2=$SOURCE.asc
       SOURCE_URL=https://github.com/lxqt/$SPELL/releases/download/$VERSION/$SOURCE

--- a/lxqt/qtxdg-tools/HISTORY
+++ b/lxqt/qtxdg-tools/HISTORY
@@ -1,3 +1,6 @@
+2022-11-24 Conner Clere <connerclere@gmail.com>
+	* DETAILS: version 3.10.0
+
 2022-07-17 Treeve Jelbert <treeve@sourcemage.org>
 	* DETAILS: version 3.9.1
 	  spell created


### PR DESCRIPTION
Patch has been applied to lxqt-session to allow it to work with procps-ng version 4, patch does not work with v4.1 though. Patch will be updated when lxqt fixes itself with the newest procps-ng