### PR TITLE
nbd: version bumped to 3.25

### DIFF
--- a/net/nbd/DEPENDS
+++ b/net/nbd/DEPENDS
@@ -5,6 +5,16 @@ optional_depends SYSTEM-LOGGER \
                  "--disable-syslog" \
                  "for Syslog logging" &&
 
+optional_depends gnutls \
+                 "--with-gnutls" \
+                 "--without-gnutls" \
+                 "for support for TLS encryption" &&
+
+optional_depends libnl \
+                 "--with-libnl" \
+                 "--without-libnl" \
+                 "for enabling netlink sockets" &&
+
 optional_depends zlib \
                  "--enable-gznbd" \
                  "--disable-gznbd" \

--- a/net/nbd/DETAILS
+++ b/net/nbd/DETAILS
@@ -1,10 +1,10 @@
            SPELL=nbd
-         VERSION=3.17
-     SOURCE_HASH=sha512:bcbd025d829d407dc3c0b837cbc1c16f673c5f4c0483d5bee83a52b40d528088499860c775e4e77cf47a8ac1d83dcda24df1092d658dd915ed01c638b3ebc57b
+         VERSION=3.25
+     SOURCE_HASH=sha512:e8b83475a698b5c3718331b55a2c28fd10ca031e347aac7c439f1653d78a405fefa5cb2618e60f73b2f170a8c93d68e79a2cd5875e5c6a970cb1ef9d8e08ebda
           SOURCE=${SPELL}-${VERSION}.tar.xz
-   SOURCE_URL[0]=http://downloads.sourceforge.net/sourceforge/$SPELL/$SOURCE
+   SOURCE_URL[0]=https://github.com/NetworkBlockDevice/$SPELL/releases/download/${SPELL}-${VERSION}/$SOURCE
 SOURCE_DIRECTORY="${BUILD_DIRECTORY}/${SPELL}-${VERSION}"
-        WEB_SITE=http://nbd.sourceforge.net/
+        WEB_SITE=https://nbd.sourceforge.net/
          ENTERED=20120827
       LICENSE[0]=GPL
            SHORT="Network Block Device (TCP version) userland"

--- a/net/nbd/HISTORY
+++ b/net/nbd/HISTORY
@@ -1,3 +1,8 @@
+2023-08-06 Stephane Fontaine <esselfe16@gmail.com>
+	* DETAILS: updated spell to 3.25 and use archive on Github
+	  instead of Sourceforge as it's more recent there.
+	* PRE_BUILD: created, fix build error in gznbd.c
+
 2018-04-30 Ismael Luceno <ismael@sourcemage.org>
 	* DETAILS: Changed SOURCE_URL[0] extension
 	  updated spell to 3.17

--- a/net/nbd/PRE_BUILD
+++ b/net/nbd/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+cd "$SOURCE_DIRECTORY" &&
+sedit 's/handle/cookie/g' gznbd/gznbd.c


### PR DESCRIPTION
- Use source archive on github instead of sourceforge
- Create PRE_BUILD to fix a build error in gznbd.c