### PR TITLE
grub2: fix install error with new e2fsprogs 1.47.0 (patch)

### DIFF
--- a/disk/grub2/DETAILS
+++ b/disk/grub2/DETAILS
@@ -1,7 +1,7 @@
 # Watch: https://ftp.gnu.org/gnu/grub grub-([0-9.]+)[.]tar
            SPELL=grub2
   STAGED_INSTALL="off"
-      PATCHLEVEL=1
+      PATCHLEVEL=2
 case "$GRUB2_RELEASE" in
   (beta|stable|*)
          VERSION=2.06

--- a/disk/grub2/HISTORY
+++ b/disk/grub2/HISTORY
@@ -1,3 +1,8 @@
+2023-08-24 Stephane Fontaine <esselfe16@gmail.com>
+	* PRE_BUILD: add a patch to fix installation errors with
+	  the new e2fsprogs 1.47.0 (metadata_csum_seed now enabled
+	  by default)
+
 2023-03-27 Ismael Luceno <ismael@sourcemage.org>
 	* DETAILS: removed old beta release
 

--- a/disk/grub2/PRE_BUILD
+++ b/disk/grub2/PRE_BUILD
@@ -1,6 +1,8 @@
 default_pre_build &&
 cd "${SOURCE_DIRECTORY}" &&
 
+patch -p1 < "$SCRIPT_DIRECTORY/grub2-ignore_ext4_checksum_seed_feature.patch" &&
+
 if [[ "$GRUB2_RELEASE" != "stable" ]]; then
   ./autogen.sh
 fi

--- a/disk/grub2/grub2-ignore_ext4_checksum_seed_feature.patch
+++ b/disk/grub2/grub2-ignore_ext4_checksum_seed_feature.patch
@@ -1,0 +1,38 @@
+Suggested-by: Eric Sandeen <esandeen@redhat.com>
+Suggested-by: Lukas Czerner <lczerner@redhat.com>
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Regenerated-by: Stephane Fontaine <esselfe16@gmail.com>
+---
+
+diff -ur grub-2.06-orig/grub-core/fs/ext2.c grub-2.06-new/grub-core/fs/ext2.c
+--- grub-2.06-orig/grub-core/fs/ext2.c	2021-06-01 11:16:48.000000000 -0400
++++ grub-2.06-new/grub-core/fs/ext2.c	2023-08-24 16:54:31.890991253 -0400
+@@ -103,6 +103,7 @@
+ #define EXT4_FEATURE_INCOMPAT_64BIT		0x0080
+ #define EXT4_FEATURE_INCOMPAT_MMP		0x0100
+ #define EXT4_FEATURE_INCOMPAT_FLEX_BG		0x0200
++#define EXT4_FEATURE_INCOMPAT_CSUM_SEED        0x2000
+ #define EXT4_FEATURE_INCOMPAT_ENCRYPT          0x10000
+ 
+ /* The set of back-incompatible features this driver DOES support. Add (OR)
+@@ -112,6 +113,7 @@
+                                        | EXT4_FEATURE_INCOMPAT_FLEX_BG \
+                                        | EXT2_FEATURE_INCOMPAT_META_BG \
+                                        | EXT4_FEATURE_INCOMPAT_64BIT \
++                                       | EXT4_FEATURE_INCOMPAT_CSUM_SEED \
+                                        | EXT4_FEATURE_INCOMPAT_ENCRYPT)
+ /* List of rationales for the ignored "incompatible" features:
+  * needs_recovery: Not really back-incompatible - was added as such to forbid
+@@ -123,6 +125,12 @@
+  * mmp:            Not really back-incompatible - was added as such to
+  *                 avoid multiple read-write mounts. Safe to ignore for this
+  *                 RO driver.
++ * checksum seed:  Not really back-incompatible - was added to allow tools
++ *                 such as tune2fs to change the UUID on a mounted metadata
++ *                 checksummed filesystem. Safe to ignore for now since the
++ *                 driver doesn't support checksum verification. But it must
++ *                 be removed from this list if that support is added later.
++ *
+  */
+ #define EXT2_DRIVER_IGNORED_INCOMPAT ( EXT3_FEATURE_INCOMPAT_RECOVER \
+ 				     | EXT4_FEATURE_INCOMPAT_MMP)


### PR DESCRIPTION
The patch is from https://lists.gnu.org/archive/html/grub-devel/2021-06/msg00031.html and had to be regenerated.